### PR TITLE
Fix panic at startup when vim mode is enabled

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -846,16 +846,7 @@
   },
   {
     "context": "MessageEditor > Editor && VimControl",
-    "bindings": {
-      "enter": "agent::Chat",
-      // TODO: Implement search
-      "/": null,
-      "?": null,
-      "#": null,
-      "*": null,
-      "n": null,
-      "shift-n": null
-    }
+    "bindings": {}
   },
   {
     "context": "os != macos && Editor && edit_prediction_conflict",


### PR DESCRIPTION
Crashes at launch with the following:


```
2025-06-20T18:19:35+10:00 INFO  [zed] ========== starting zed ==========
2025-06-20T18:19:35+10:00 INFO  [db] Opening main db
2025-06-20T18:19:35+10:00 INFO  [db] Opening main db
2025-06-20T18:19:35+10:00 INFO  [zed] Using git binary path: None
2025-06-20T18:19:35+10:00 ERROR [zed::reliability] {
  "thread": "main",
  "payload": "called `Result::unwrap()` on an `Err` value: Error loading built-in keymap \"keymaps/vim.json\": Errors in user keymap file.\n\n\nIn section with `context = \"MessageEditor > Editor && VimControl\"`:\n\n- In binding `\"enter\"`, didn't find an action named `\"agent::Chat\"`.",
  "location_data": {
    "file": "crates/zed/src/zed.rs",
    "line": 1322
  },
  "backtrace": [
    "zed::reliability::init_panic_hook::{{closure}}::h08874439017e90c5+149137281",
    "<alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h8c92344f37e80662+123415235",
    "std::panicking::rust_panic_with_hook::h2987c5ae6c22dc3e+123415235",
    "std::panicking::begin_panic_handler::{{closure}}::h95de0b0725e68345+123414426",
    "std::sys::backtrace::__rust_end_short_backtrace::hc1bc731d5db91fa0+123407481",
    "__rustc[386ee042c3d2115]::rust_begin_unwind+123413565",
    "core::panicking::panic_fmt::h823925515fbe0bff+46943424",
    "core::result::unwrap_failed::h651e1ffcf75337a1+46944486",
    "core::result::Result<T,E>::unwrap::h3f117b946fd4f5b3+148932779",
    "zed::zed::load_default_keymap::h9e60670faea850db+148932779",
    "zed::zed::handle_keymap_file_changes::h1495cc888a5331a2+148930256",
    "zed::main::{{closure}}::hb5635b3114f60865+146824778",
    "gpui::app::Application::run::{{closure}}::hed6a6f5282adc06e+146099510",
    "core::ops::function::FnOnce::call_once{{vtable.shim}}::hb27bc4a1f8043c89+146099510",
    "<alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hab31fc3916e6a6f5+79157044",
    "gpui::platform::linux::platform::<impl gpui::platform::Platform for P>::run::h1e948d8dea984abb+79157044",
    "gpui::app::Application::run::hd6c65813d1589c19+146191716",
    "zed::main::h4c07b1a95232fe38+150069122",
    "core::ops::function::FnOnce::call_once::hc614bc1bcdaf9600+150367619",
    "std::sys::backtrace::__rust_begin_short_backtrace::hf332ae4be04a507c+150367619",
    "std::rt::lang_start::{{closure}}::h113c900f23ac66c8+150367593",
    "core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::hcacb4f80a4abdcc9+123334305",
    "std::panicking::try::do_call::hcdc058a1c0dfc5af+123334305",
    "std::panicking::try::h1c0ce616bac58cf7+123334305",
    "std::panic::catch_unwind::hf73b85bcffa95544+123334305",
    "std::rt::lang_start_internal::{{closure}}::ha2f7bd92c6cd6128+123334305",
    "std::panicking::try::do_call::h502ca157dc51fd1e+123334305",
    "std::panicking::try::h5843e3d90e48a464+123334305",
    "std::panic::catch_unwind::h766d525785710e3f+123334305",
    "std::rt::lang_start_internal::hd4e2faa57cb9ee8f+123334305",
    "main+150367692"
  ],
  "app_version": "0.192.0",
  "app_commit_sha": "b8436f5c84552b51ae8b9255fde0bffda1f67ce5",
  "release_channel": "stable",
  "target": "x86_64-chimera-linux-musl",
  "os_name": "Linux Wayland",
  "os_version": "chimera unknown",
  "architecture": "x86_64",
  "panicked_on": 1750407575971,
  "system_id": "62ced264-076b-4225-94a7-250e5a73510b",
  "installation_id": "90f4c502-6b2a-427d-b348-4cf464168305",
  "session_id": "718e7674-0482-4cb3-b346-90941297831f"
}
[1]    26993 abort      cargo run --release
```